### PR TITLE
chore(app): change default ending domain

### DIFF
--- a/articles/consuming-spotify-apis.mdx
+++ b/articles/consuming-spotify-apis.mdx
@@ -24,7 +24,7 @@ author:
 
 Finally, another article in my (poor 😓) blog. Sometimes I don't know what to say, or what to explain you. But in this case, I show you how I've integrated **Spotify** API's into my website.
 
-As you can see in this [section](https://mateonunez.dev/spotify) I made 2 sections showing you my the **Last Songs I Played**, the **Top Artists** and my **Top Tracks**.
+As you can see in this [section](https://mateonunez.co/spotify) I made 2 sections showing you my the **Last Songs I Played**, the **Top Artists** and my **Top Tracks**.
 
 ## 👨‍🍳️ Ingredients
 
@@ -434,7 +434,7 @@ export default React.memo(Player);
 
 ## 🔁 Recently Played
 
-The [preview](https://mateonunez.dev/spotify).
+The [preview](https://mateonunez.co/spotify).
 
 <Image
   src="/images/articles/consuming-spotify-apis/recently-played.png"

--- a/articles/nextjs-appdir-migration.mdx
+++ b/articles/nextjs-appdir-migration.mdx
@@ -220,7 +220,7 @@ const author = {
   twitter: '@mmateonunez',
   github: '@mateonunez',
   email: 'mateonunez95@gmail.com',
-  website: 'https://mateonunez.dev'
+  website: 'https://mateonunez.co'
 };
 
 const defaultTitle = '@mateonunez';
@@ -253,7 +253,7 @@ const metadata = {
     sitename: defaultTitle,
     images: [
       {
-        url: 'https://mateonunez.dev/card.png',
+        url: 'https://mateonunez.co/card.png',
         width: 512,
         height: 512,
         alt: 'Mateo Nunez'

--- a/lib/config/personal.ts
+++ b/lib/config/personal.ts
@@ -9,7 +9,7 @@ export const personal = {
   company: 'BonusX',
 
   email: 'mateonunez95@gmail.com',
-  website: 'https://mateonunez.dev',
+  website: 'https://mateonunez.co',
 
   location: {
     origin: 'Colombia',
@@ -27,7 +27,7 @@ export const personal = {
 
   assets: {
     avatar: '/images/profile.jpg',
-    ogImage: 'https://mateonunez.dev/card.png',
+    ogImage: 'https://mateonunez.co/card.png',
     favicons: {
       ico: '/favicon.ico',
       apple: '/apple-touch-icon.png',
@@ -70,7 +70,7 @@ export const personal = {
   },
 
   bio: {
-    full: "Hey, I'm Mateo Nunez, a Senior Software Engineer at BonusX who's been coding dope shit for over a decade. I'm all about open-source, tweaking my site (mateonunez.dev), and sipping coffee while blasting tunes. Right now, I'm cooking an AI side project that'll drop soon—stay tuned, fam!",
+    full: "Hey, I'm Mateo Nunez, a Senior Software Engineer at BonusX who's been coding dope shit for over a decade. I'm all about open-source, tweaking my site (mateonunez.co), and sipping coffee while blasting tunes. Right now, I'm cooking an AI side project that'll drop soon—stay tuned, fam!",
     short:
       "Hey, I'm Mateo Nunez, a Senior Software Engineer at BonusX who's been coding dope shit for over a decade. I dig crafting slick web apps and jamming to Spotify while I code.",
   },
@@ -109,7 +109,7 @@ export const personal = {
 
   languagesSpoken: ['Italian', 'Spanish', 'English'],
 
-  currentWork: ['AIt', 'Refactoring mateonunez.dev', 'Keeping legacy code alive', "Chillin' with coffee and tunes"],
+  currentWork: ['AIt', 'Refactoring mateonunez.co', 'Keeping legacy code alive', "Chillin' with coffee and tunes"],
 
   profileBadges: [
     { label: 'Code Crafter', icon: 'Code', description: 'Full-stack wizard with a chill twist' },

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,10 +6,10 @@ import rehypeSlug from 'rehype-slug';
 import remarkGfm from 'remark-gfm';
 
 const contentSecurityPolicy = `
-  default-src 'self' https://*.googletagmanager.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://*.vercel-insights.com https://vercel.live https://mateonunez.dev/;
+  default-src 'self' https://*.googletagmanager.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://*.vercel-insights.com https://vercel.live https://mateonunez.co/;
   base-uri 'self';
   block-all-mixed-content;
-  connect-src 'self' https://*.googletagmanager.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://*.vercel-insights.com https://vercel.live https://mateonunez.dev/;
+  connect-src 'self' https://*.googletagmanager.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://*.vercel-insights.com https://vercel.live https://mateonunez.co/;
   font-src 'self' https://fonts.gstatic.com https://*.vercel.com https://vercel.live;
   frame-ancestors 'self';
   img-src 'self' data: https://i.scdn.co https://avatars.githubusercontent.com https://*.googletagmanager.com https://*.google-analytics.com https://*.vercel.com https://*.vercel-insights.com https://vercel.live https://*.google.com https://*.google.it https://*.githubassets.com https://*.githubusercontent.com https://*.github.com https://*.gstatic.com;


### PR DESCRIPTION
> [!NOTE]
> 
> Description generated by AI

This pull request includes several changes to update the website URL references from `mateonunez.dev` to `mateonunez.co` across multiple files. The most important changes include updates in the articles, personal configuration, and content security policy.

Updates to articles:

* [`articles/consuming-spotify-apis.mdx`](diffhunk://#diff-cb4d5445090ea513ac6922355478c69cd503a5300f28883331c774a9594a1e64L27-R27): Updated the website URL in the text and preview links. [[1]](diffhunk://#diff-cb4d5445090ea513ac6922355478c69cd503a5300f28883331c774a9594a1e64L27-R27) [[2]](diffhunk://#diff-cb4d5445090ea513ac6922355478c69cd503a5300f28883331c774a9594a1e64L437-R437)
* [`articles/nextjs-appdir-migration.mdx`](diffhunk://#diff-24cecef7a99c565216ece4cdea860c0603b709f0909a68a280904a9a91db235eL223-R223): Changed the website URL in the `author` object and metadata. [[1]](diffhunk://#diff-24cecef7a99c565216ece4cdea860c0603b709f0909a68a280904a9a91db235eL223-R223) [[2]](diffhunk://#diff-24cecef7a99c565216ece4cdea860c0603b709f0909a68a280904a9a91db235eL256-R256)

Updates to personal configuration:

* [`lib/config/personal.ts`](diffhunk://#diff-1d492d5d0233f7e3c8aad092eb7947ff41cdb01c453c93f17ab35c66561d4db5L12-R12): Updated the website URL in the `personal` object, including the `website`, `ogImage`, `bio`, and `currentWork` fields. [[1]](diffhunk://#diff-1d492d5d0233f7e3c8aad092eb7947ff41cdb01c453c93f17ab35c66561d4db5L12-R12) [[2]](diffhunk://#diff-1d492d5d0233f7e3c8aad092eb7947ff41cdb01c453c93f17ab35c66561d4db5L30-R30) [[3]](diffhunk://#diff-1d492d5d0233f7e3c8aad092eb7947ff41cdb01c453c93f17ab35c66561d4db5L73-R73) [[4]](diffhunk://#diff-1d492d5d0233f7e3c8aad092eb7947ff41cdb01c453c93f17ab35c66561d4db5L112-R112)

Updates to content security policy:

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bL9-R12): Updated the website URL in the `contentSecurityPolicy` string.